### PR TITLE
2.0.24-canva

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.24-canva</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/debugger-app/pom.xml
+++ b/debugger-app/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.24-canva</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/debugger/pom.xml
+++ b/debugger/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.24-canva</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.24-canva</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/fontbox/pom.xml
+++ b/fontbox/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.24-canva</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -33,7 +33,7 @@
 
     <groupId>org.apache.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.24-canva</version>
     <packaging>pom</packaging>
 
     <name>PDFBox parent</name>
@@ -147,7 +147,7 @@
                     <plugin>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <configuration>
-                            <release>6</release>
+                            <release>8</release>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -322,7 +322,7 @@
         </plugins>
         <pluginManagement>
             <plugins>
-                <plugin>
+                <!--<plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <executions>
                         <execution>
@@ -344,7 +344,7 @@
                             </configuration>
                         </execution>
                     </executions>
-                </plugin>
+                </plugin> -->
                 <plugin>
                     <groupId>org.apache.rat</groupId>
                     <artifactId>apache-rat-plugin</artifactId>

--- a/pdfbox/pom.xml
+++ b/pdfbox/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.pdfbox</groupId>
         <artifactId>pdfbox-parent</artifactId>
-        <version>2.0.24</version>
+        <version>2.0.24-canva</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/pdfbox/src/main/java/org/apache/pdfbox/rendering/PageDrawer.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/rendering/PageDrawer.java
@@ -897,7 +897,10 @@ public class PageDrawer extends PDFGraphicsStreamEngine
         {
             // apply clip to path to avoid oversized device bounds in shading contexts (PDFBOX-2901)
             Area area = new Area(linePath);
-            area.intersect(new Area(graphics.getClip()));
+            if (graphics.getClip() != null)
+            {
+                area.intersect(new Area(graphics.getClip()));
+            }
             intersectShadingBBox(getGraphicsState().getNonStrokingColor(), area);
             shape = area;
         }
@@ -1556,6 +1559,12 @@ public class PageDrawer extends PDFGraphicsStreamEngine
 
     @Override
     public void showTransparencyGroup(PDTransparencyGroup form) throws IOException
+    {
+        showTransparencyGroupOnGraphics(form, graphics);
+    }
+
+    protected void showTransparencyGroupOnGraphics(PDTransparencyGroup form, Graphics2D graphics)
+            throws IOException
     {
         if (isHiddenOCG(form.getOptionalContent()))
         {

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.24-canva</version>
     <relativePath>parent/pom.xml</relativePath>
   </parent>
 

--- a/preflight-app/pom.xml
+++ b/preflight-app/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.24-canva</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/preflight/pom.xml
+++ b/preflight/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<groupId>org.apache.pdfbox</groupId>
 		<artifactId>pdfbox-parent</artifactId>
-		<version>2.0.24</version>
+		<version>2.0.24-canva</version>
 		<relativePath>../parent/pom.xml</relativePath>
 	</parent>
         

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.pdfbox</groupId>
     <artifactId>pdfbox-parent</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.24-canva</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/xmpbox/pom.xml
+++ b/xmpbox/pom.xml
@@ -27,7 +27,7 @@
 	<parent>
 		<groupId>org.apache.pdfbox</groupId>
 		<artifactId>pdfbox-parent</artifactId>
-		<version>2.0.24</version>
+		<version>2.0.24-canva</version>
 		<relativePath>../parent/pom.xml</relativePath>
 	</parent>
 


### PR DESCRIPTION
This PR is branched of the PdfBox [2.0.24 tag](https://github.com/Canva/pdfbox/releases/tag/2.0.24), and adds a few workarounds for issues that are already fixed in the official PdfBox `trunk`, but haven't been released yet.

It cannot be merged, but I created a new tag [2.0.24-canva-1](https://github.com/Canva/pdfbox/releases/tag/2.0.24-canva-1), and will upload the generated artifacts to our S3 bucket, such that we can use `2.0.24-canva` until `3.0.0` or `2.0.25` have been released.

cc @Canva/design-import 